### PR TITLE
OT132-67: Elimination's endpoint for Testimonials

### DIFF
--- a/etc/postman/OT132.postman_collection.json
+++ b/etc/postman/OT132.postman_collection.json
@@ -264,6 +264,36 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "Remove Testimonial",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX0FETUlOIl0sInN1YiI6ImV0bHVpdDEyQGdtYWlsLmNvbSIsImlhdCI6MTY0NDM1MzA5NSwiZXhwIjoxNjQ0Mzg5MDk1fQ.vr1W5NLWsWJ-F1R9rlTJfOMXZX2eWGVVjtYUyDkQLLQ",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8080/testimonials/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "8080",
+              "path": [
+                "testimonials",
+                "1"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },

--- a/src/main/java/com/alkemy/ong/config/segurity/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/segurity/SecurityConfig.java
@@ -83,6 +83,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .hasAnyRole(RoleType.ADMIN.name())
         .antMatchers(HttpMethod.POST, "/testimonials")
         .hasAnyRole(RoleType.ADMIN.name(), RoleType.USER.name())
+        .antMatchers(HttpMethod.DELETE, "/testimonials/{id:[\\d+]}")
+        .hasAnyRole(RoleType.ADMIN.name(), RoleType.USER.name())
         .antMatchers(HttpMethod.GET, "/members")
         .hasRole(RoleType.ADMIN.name())
         .antMatchers(HttpMethod.POST, "/members")

--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -3,10 +3,13 @@ package com.alkemy.ong.controller;
 import com.alkemy.ong.model.request.CreateTestimonialRequest;
 import com.alkemy.ong.model.response.TestimonialResponse;
 import com.alkemy.ong.service.abstraction.ICreateTestimonial;
+import com.alkemy.ong.service.abstraction.IDeleteTestimonial;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +22,9 @@ public class TestimonialController {
   @Autowired
   private ICreateTestimonial createTestimonial;
 
+  @Autowired
+  private IDeleteTestimonial deleteTestimonial;
+
   @PostMapping
   public ResponseEntity<TestimonialResponse> create(
       @RequestBody @Valid CreateTestimonialRequest createTestimonialRequest) {
@@ -26,4 +32,9 @@ public class TestimonialController {
     return ResponseEntity.status(HttpStatus.CREATED).body(testimonialResponse);
   }
 
+  @DeleteMapping("{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    deleteTestimonial.delete(id);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/src/main/java/com/alkemy/ong/repository/ITestimonialRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/ITestimonialRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ITestimonialRepository extends JpaRepository<Testimonial, Long> {
 
+  Testimonial findByTestimonialIdAndSoftDeleteFalse(Long id);
 }

--- a/src/main/java/com/alkemy/ong/service/TestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/TestimonialService.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.service;
 
+import com.alkemy.ong.exception.NotFoundException;
 import com.alkemy.ong.mapper.TestimonialMapper;
 import com.alkemy.ong.mapper.attribute.TestimonialAttributes;
 import com.alkemy.ong.model.entity.Testimonial;
@@ -7,11 +8,12 @@ import com.alkemy.ong.model.request.CreateTestimonialRequest;
 import com.alkemy.ong.model.response.TestimonialResponse;
 import com.alkemy.ong.repository.ITestimonialRepository;
 import com.alkemy.ong.service.abstraction.ICreateTestimonial;
+import com.alkemy.ong.service.abstraction.IDeleteTestimonial;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class TestimonialService implements ICreateTestimonial {
+public class TestimonialService implements ICreateTestimonial, IDeleteTestimonial {
 
   @Autowired
   private ITestimonialRepository testimonialRepository;
@@ -28,5 +30,17 @@ public class TestimonialService implements ICreateTestimonial {
         TestimonialAttributes.CONTENT,
         TestimonialAttributes.IMAGE,
         TestimonialAttributes.NAME);
+  }
+
+  @Override
+  public void delete(Long id) {
+    Testimonial testimonial = testimonialRepository.findByTestimonialIdAndSoftDeleteFalse(id);
+
+    if (testimonial == null) {
+      throw new NotFoundException("Testimonial not found");
+    }
+
+    testimonial.setSoftDelete(true);
+    testimonialRepository.save(testimonial);
   }
 }

--- a/src/main/java/com/alkemy/ong/service/abstraction/IDeleteTestimonial.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/IDeleteTestimonial.java
@@ -1,0 +1,6 @@
+package com.alkemy.ong.service.abstraction;
+
+public interface IDeleteTestimonial {
+
+  void delete(Long id);
+}


### PR DESCRIPTION
Added delete endpoint to TestimonialController.
#### Modified
* SecurityConfig
* TestimonialController
* ITestimonialRepository
* TestimonialService

#### Created
* IDeleteTestimonial

#### Tests with Postman and DBeaver

* #### Rows without changes in soft_delete
![Imgur](https://i.imgur.com/DrUvVjE.png)

* #### Executed delete over Row 1
![Imgur](https://i.imgur.com/RmusOaP.png)

* #### soft_delete from row 1 changed
![Imgur](https://i.imgur.com/8mA2S8A.png)

* #### Error to try to delete with id 1
![Imgur](https://i.imgur.com/S5Yjc0i.png)