### PR TITLE
OT132-77: Actualization's endpoint for Comments

### DIFF
--- a/src/main/java/com/alkemy/ong/config/segurity/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/segurity/SecurityConfig.java
@@ -123,6 +123,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         .hasAnyRole(RoleType.USER.name(), RoleType.ADMIN.name())
         .antMatchers(HttpMethod.POST, "/comments")
         .hasAnyRole(RoleType.USER.name())
+        .antMatchers(HttpMethod.PUT, "/comments/{id:[\\d+]}")
+        .hasAnyRole(RoleType.ADMIN.name(), RoleType.USER.name())
         .antMatchers(HttpMethod.GET, "/categories/{\\d+}")
         .hasRole(RoleType.ADMIN.name())
         .antMatchers(HttpMethod.DELETE, "/slides/{id:[\\d+]}")

--- a/src/main/java/com/alkemy/ong/controller/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/CommentController.java
@@ -1,16 +1,23 @@
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.exception.InsufficientPermissionsException;
 import com.alkemy.ong.exception.NotFoundException;
 import com.alkemy.ong.model.request.CreateCommentRequest;
+import com.alkemy.ong.model.request.UpdateCommentRequest;
+import com.alkemy.ong.model.response.CommentResponse;
 import com.alkemy.ong.model.response.ListCommentResponse;
 import com.alkemy.ong.service.abstraction.ICreateComment;
 import com.alkemy.ong.service.abstraction.IGetComment;
+import com.alkemy.ong.service.abstraction.IUpdateComment;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +32,9 @@ public class CommentController {
   @Autowired
   private ICreateComment createComment;
 
+  @Autowired
+  private IUpdateComment updateComment;
+
   @GetMapping
   public ResponseEntity<ListCommentResponse> list() {
     ListCommentResponse listResponse = getComment.findAll();
@@ -36,5 +46,14 @@ public class CommentController {
       throws NotFoundException {
     createComment.create(createCommentRequest);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<CommentResponse> update(@PathVariable Long id,
+      @Valid @RequestBody UpdateCommentRequest updateCommentRequest, Authentication authentication)
+      throws InsufficientPermissionsException {
+    CommentResponse commentResponse = updateComment.update(id, updateCommentRequest,
+        authentication);
+    return ResponseEntity.ok().body(commentResponse);
   }
 }

--- a/src/main/java/com/alkemy/ong/exception/GlobalHandleException.java
+++ b/src/main/java/com/alkemy/ong/exception/GlobalHandleException.java
@@ -63,6 +63,13 @@ public class GlobalHandleException {
     return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
   }
 
+  @ExceptionHandler(value = InsufficientPermissionsException.class)
+  public ResponseEntity<ErrorResponse> handleInsufficientPermissionsException(
+      InsufficientPermissionsException e) {
+    ErrorResponse error = buildErrorResponse(HttpStatus.FORBIDDEN,e.getMessage());
+    return new ResponseEntity<>(error,HttpStatus.FORBIDDEN);
+  }
+
   private ErrorResponse buildErrorResponse(HttpStatus httpStatus, String message) {
     ErrorResponse error = new ErrorResponse();
     error.setStatus(httpStatus.value());

--- a/src/main/java/com/alkemy/ong/exception/InsufficientPermissionsException.java
+++ b/src/main/java/com/alkemy/ong/exception/InsufficientPermissionsException.java
@@ -1,0 +1,8 @@
+package com.alkemy.ong.exception;
+
+public class InsufficientPermissionsException extends Exception {
+
+  public InsufficientPermissionsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/alkemy/ong/mapper/CommentMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/CommentMapper.java
@@ -30,4 +30,11 @@ public class CommentMapper {
     comment.setUser(user);
     return comment;
   }
+
+  public CommentResponse map(Comment comment) {
+    CommentResponse commentResponse = new CommentResponse();
+    commentResponse.setBody(comment.getBody());
+    commentResponse.setTimestamp(comment.getTimestamp());
+    return commentResponse;
+  }
 }

--- a/src/main/java/com/alkemy/ong/mapper/CommentMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/CommentMapper.java
@@ -15,10 +15,7 @@ public class CommentMapper {
   public List<CommentResponse> map(List<Comment> comments) {
     List<CommentResponse> commentResponses = new ArrayList<>(comments.size());
     for (Comment comment : comments) {
-      CommentResponse commentResponse = new CommentResponse();
-      commentResponse.setBody(comment.getBody());
-      commentResponse.setTimestamp(comment.getTimestamp());
-      commentResponses.add(commentResponse);
+      commentResponses.add(map(comment));
     }
     return commentResponses;
   }

--- a/src/main/java/com/alkemy/ong/model/request/UpdateCommentRequest.java
+++ b/src/main/java/com/alkemy/ong/model/request/UpdateCommentRequest.java
@@ -1,0 +1,20 @@
+package com.alkemy.ong.model.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateCommentRequest {
+
+  @NotNull(message = "The user ID cannot be null or empty.")
+  private Long userId;
+
+  @NotNull(message = "The news ID cannot be null or empty.")
+  private Long newsId;
+
+  @NotBlank(message = "The body cannot be null or empty.")
+  private String body;
+}

--- a/src/main/java/com/alkemy/ong/service/CommentService.java
+++ b/src/main/java/com/alkemy/ong/service/CommentService.java
@@ -1,11 +1,13 @@
 package com.alkemy.ong.service;
 
+import com.alkemy.ong.exception.InsufficientPermissionsException;
 import com.alkemy.ong.exception.NotFoundException;
 import com.alkemy.ong.mapper.CommentMapper;
 import com.alkemy.ong.model.entity.Comment;
 import com.alkemy.ong.model.entity.News;
 import com.alkemy.ong.model.entity.User;
 import com.alkemy.ong.model.request.CreateCommentRequest;
+import com.alkemy.ong.model.request.UpdateCommentRequest;
 import com.alkemy.ong.model.response.CommentResponse;
 import com.alkemy.ong.model.response.ListCommentResponse;
 import com.alkemy.ong.repository.ICommentRepository;
@@ -13,12 +15,18 @@ import com.alkemy.ong.repository.INewsRepository;
 import com.alkemy.ong.repository.IUserRepository;
 import com.alkemy.ong.service.abstraction.ICreateComment;
 import com.alkemy.ong.service.abstraction.IGetComment;
+import com.alkemy.ong.service.abstraction.IUpdateComment;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CommentService implements IGetComment, ICreateComment {
+public class CommentService implements IGetComment, ICreateComment,
+    IUpdateComment {
 
   @Autowired
   private ICommentRepository commentRepository;
@@ -49,4 +57,38 @@ public class CommentService implements IGetComment, ICreateComment {
     commentRepository.save(commentMapper.map(createCommentRequest, user, news));
   }
 
+  @Override
+  public CommentResponse update(Long id, UpdateCommentRequest updateCommentRequest,
+      Authentication authentication) throws InsufficientPermissionsException {
+    Comment comment = findBy(id);
+    News news = newsRepository.findByNewsIdAndSoftDeleteFalse(updateCommentRequest.getNewsId());
+    User user = userRepository.findByUserIdAndSoftDeleteFalse(updateCommentRequest.getUserId());
+    checkUser(comment, authentication);
+    updateValues(comment, updateCommentRequest, news, user);
+    commentRepository.save(comment);
+    return commentMapper.map(comment);
+  }
+
+  private Comment findBy(Long id) {
+    Optional<Comment> result = commentRepository.findById(id);
+    if (result.isEmpty()) {
+      throw new NotFoundException("Comment not found");
+    }
+    return result.get();
+  }
+
+  private void checkUser(Comment comment, Authentication authentication)
+      throws InsufficientPermissionsException {
+    if (!authentication.getName().equals(comment.getUser().getEmail())) {
+      throw new InsufficientPermissionsException("Unauthorized to do changes");
+    }
+  }
+
+  private void updateValues(Comment comment, UpdateCommentRequest updateCommentRequest, News news,
+      User user) {
+    comment.setBody(updateCommentRequest.getBody());
+    comment.setNews(news);
+    comment.setUser(user);
+    comment.setTimestamp(Timestamp.from(Instant.now()));
+  }
 }

--- a/src/main/java/com/alkemy/ong/service/abstraction/IUpdateComment.java
+++ b/src/main/java/com/alkemy/ong/service/abstraction/IUpdateComment.java
@@ -1,0 +1,12 @@
+package com.alkemy.ong.service.abstraction;
+
+import com.alkemy.ong.exception.InsufficientPermissionsException;
+import com.alkemy.ong.model.request.UpdateCommentRequest;
+import com.alkemy.ong.model.response.CommentResponse;
+import org.springframework.security.core.Authentication;
+
+public interface IUpdateComment {
+
+  CommentResponse update(Long id, UpdateCommentRequest updateCommentRequest,
+      Authentication authentication) throws InsufficientPermissionsException;
+}


### PR DESCRIPTION
Added update endpoint to CommentController.

#### Modified

- SecurityConfig
- CommentController
- CommentMapper
- CommentService
- GlobalHandleException

#### Created

- InsufficientPermissonsException
- UpdateCommentRequest
- IUpdateComment

#### Tests with Postman and DBeaver

- #### Rows 1 without changes

  ![Imgur](https://i.imgur.com/ONdtGw6.png)

- #### Executed update over Row 1 with user id 2

  ![Imgur](https://i.imgur.com/jS4pr1t.png)

- #### Row 1 changed

  ![Imgur](https://i.imgur.com/w5IXQbb.png)

- #### Error to try to update with a different user

  ![Imgur](https://i.imgur.com/1xO0yHR.png)

- #### Error to try to update a non-existent row
![Imgur](https://i.imgur.com/Tcfyxqm.png)