### PR TITLE
OT132-91: Member's test

### DIFF
--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -1,0 +1,18 @@
+package com.alkemy.ong.integration.member;
+
+import com.alkemy.ong.integration.common.AbstractBaseIntegrationTest;
+
+public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTest {
+
+  protected final static String MEMBER_PATH = "/members";
+  protected final static String NAME = "Joe";
+  protected final static String FACEBOOK_URL = "facebookUrl";
+  protected final static String INSTAGRAM_URL = "instagramUrl";
+  protected final static String LINKEDIN_URL = "linkedinUrl";
+  protected final static String IMAGE =
+      "https://cohorte-enero-835eb560.s3-us-east-2.amazonaws.com/image.txt";
+  protected final static String DESCRIPTION = "This is a description";
+  protected final static boolean SOFT_DELETE = false;
+
+
+}

--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.ResponseEntity;
 
-public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTest {
+public abstract class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTest {
 
   protected final static String PATH = "/members";
   protected final static String NAME = "Joe";
@@ -39,11 +39,11 @@ public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTe
 
   protected Page<Member> buildMemberStubPage(){
     List<Member> members = new ArrayList<>();
-    members.add(creteMember());
+    members.add(createMember());
     return new PageImpl<>(members);
   }
 
-  private Member creteMember() {
+  private Member createMember() {
     Member member = new Member();
     member.setName(NAME);
     member.setFacebookUrl(FACEBOOK_URL);

--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -63,6 +63,10 @@ public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTe
     return buildRequestPayload(NAME, null, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
   }
 
+  protected CreateMemberRequest buildRequestPayload() {
+    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+  }
+
   private CreateMemberRequest buildRequestPayload(String name, String image, String description,
       String facebookUrl, String instagramUrl, String linkedinUrl) {
     CreateMemberRequest memberRequest = new CreateMemberRequest();

--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -39,11 +39,11 @@ public abstract class AbstractBaseMemberIntegrationTest extends AbstractBaseInte
 
   protected Page<Member> buildMemberStubPage(){
     List<Member> members = new ArrayList<>();
-    members.add(createMember());
+    members.add(memberStub());
     return new PageImpl<>(members);
   }
 
-  private Member createMember() {
+  protected Member memberStub() {
     Member member = new Member();
     member.setName(NAME);
     member.setFacebookUrl(FACEBOOK_URL);
@@ -56,26 +56,25 @@ public abstract class AbstractBaseMemberIntegrationTest extends AbstractBaseInte
   }
 
   protected CreateMemberRequest buildRequestWithEmptyName(){
-    return buildRequestPayload(null, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+    return buildRequestPayload(null, IMAGE);
   }
 
   protected CreateMemberRequest buildRequestWithEmptyImage(){
-    return buildRequestPayload(NAME, null, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+    return buildRequestPayload(NAME, null);
   }
 
   protected CreateMemberRequest buildRequestPayload() {
-    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+    return buildRequestPayload(NAME, IMAGE);
   }
 
-  private CreateMemberRequest buildRequestPayload(String name, String image, String description,
-      String facebookUrl, String instagramUrl, String linkedinUrl) {
+  private CreateMemberRequest buildRequestPayload(String name, String image) {
     CreateMemberRequest memberRequest = new CreateMemberRequest();
     memberRequest.setName(name);
     memberRequest.setImage(image);
-    memberRequest.setDescription(description);
-    memberRequest.setFacebookUrl(facebookUrl);
-    memberRequest.setInstagramUrl(instagramUrl);
-    memberRequest.setLinkedinUrl(linkedinUrl);
+    memberRequest.setDescription(DESCRIPTION);
+    memberRequest.setFacebookUrl(FACEBOOK_URL);
+    memberRequest.setInstagramUrl(INSTAGRAM_URL);
+    memberRequest.setLinkedinUrl(LINKEDIN_URL);
     return memberRequest;
   }
 

--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -1,10 +1,13 @@
 package com.alkemy.ong.integration.member;
 
 import com.alkemy.ong.integration.common.AbstractBaseIntegrationTest;
+import com.alkemy.ong.model.request.CreateMemberRequest;
+import com.alkemy.ong.repository.IMemberRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTest {
 
-  protected final static String MEMBER_PATH = "/members";
+  protected final static String PATH = "/members";
   protected final static String NAME = "Joe";
   protected final static String FACEBOOK_URL = "facebookUrl";
   protected final static String INSTAGRAM_URL = "instagramUrl";
@@ -14,5 +17,47 @@ public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTe
   protected final static String DESCRIPTION = "This is a description";
   protected final static boolean SOFT_DELETE = false;
 
+  @MockBean
+  IMemberRepository memberRepository;
+
+  protected CreateMemberRequest buildRequestWithEmptyName(){
+    return buildRequestPayload(null, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+  }
+
+  protected CreateMemberRequest buildRequestWithEmptyImage(){
+    return buildRequestPayload(NAME, null, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+  }
+
+  protected CreateMemberRequest buildRequestWithEmptyDescription(){
+    return buildRequestPayload(NAME, IMAGE, null, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+  }
+
+  protected CreateMemberRequest buildRequestWithEmptyFacebookUrl(){
+    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, null, INSTAGRAM_URL, LINKEDIN_URL);
+  }
+
+  protected CreateMemberRequest buildRequestWithEmptyInstagramUrl(){
+    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, null, LINKEDIN_URL);
+  }
+
+  protected CreateMemberRequest buildRequestWithEmptyLinkedinUrl(){
+    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, null);
+  }
+
+  protected CreateMemberRequest buildRequestPayload() {
+    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
+  }
+
+  private CreateMemberRequest buildRequestPayload(String name, String image, String description,
+      String facebookUrl, String instagramUrl, String linkedinUrl) {
+    CreateMemberRequest memberRequest = new CreateMemberRequest();
+    memberRequest.setName(name);
+    memberRequest.setImage(image);
+    memberRequest.setDescription(description);
+    memberRequest.setFacebookUrl(facebookUrl);
+    memberRequest.setInstagramUrl(instagramUrl);
+    memberRequest.setLinkedinUrl(linkedinUrl);
+    return memberRequest;
+  }
 
 }

--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -1,10 +1,19 @@
 package com.alkemy.ong.integration.member;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
 import com.alkemy.ong.exception.ErrorResponse;
 import com.alkemy.ong.integration.common.AbstractBaseIntegrationTest;
+import com.alkemy.ong.model.entity.Member;
 import com.alkemy.ong.model.request.CreateMemberRequest;
 import com.alkemy.ong.repository.IMemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.ResponseEntity;
 
 public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTest {
@@ -22,32 +31,36 @@ public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTe
   @MockBean
   IMemberRepository memberRepository;
 
+  @Before
+  public void checkFindMethod(){
+    when(memberRepository.findBySoftDeleteFalseOrderByTimestampDesc(any()))
+        .thenReturn(buildMemberStubPage());
+  }
+
+  protected Page<Member> buildMemberStubPage(){
+    List<Member> members = new ArrayList<>();
+    members.add(creteMember());
+    return new PageImpl<>(members);
+  }
+
+  private Member creteMember() {
+    Member member = new Member();
+    member.setName(NAME);
+    member.setFacebookUrl(FACEBOOK_URL);
+    member.setInstagramUrl(INSTAGRAM_URL);
+    member.setLinkedinUrl(LINKEDIN_URL);
+    member.setImage(IMAGE);
+    member.setDescription(DESCRIPTION);
+    member.setSoftDelete(SOFT_DELETE);
+    return member;
+  }
+
   protected CreateMemberRequest buildRequestWithEmptyName(){
     return buildRequestPayload(null, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
   }
 
   protected CreateMemberRequest buildRequestWithEmptyImage(){
     return buildRequestPayload(NAME, null, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
-  }
-
-  protected CreateMemberRequest buildRequestWithEmptyDescription(){
-    return buildRequestPayload(NAME, IMAGE, null, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
-  }
-
-  protected CreateMemberRequest buildRequestWithEmptyFacebookUrl(){
-    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, null, INSTAGRAM_URL, LINKEDIN_URL);
-  }
-
-  protected CreateMemberRequest buildRequestWithEmptyInstagramUrl(){
-    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, null, LINKEDIN_URL);
-  }
-
-  protected CreateMemberRequest buildRequestWithEmptyLinkedinUrl(){
-    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, null);
-  }
-
-  protected CreateMemberRequest buildRequestPayload() {
-    return buildRequestPayload(NAME, IMAGE, DESCRIPTION, FACEBOOK_URL, INSTAGRAM_URL, LINKEDIN_URL);
   }
 
   private CreateMemberRequest buildRequestPayload(String name, String image, String description,

--- a/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/AbstractBaseMemberIntegrationTest.java
@@ -1,9 +1,11 @@
 package com.alkemy.ong.integration.member;
 
+import com.alkemy.ong.exception.ErrorResponse;
 import com.alkemy.ong.integration.common.AbstractBaseIntegrationTest;
 import com.alkemy.ong.model.request.CreateMemberRequest;
 import com.alkemy.ong.repository.IMemberRepository;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
 
 public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTest {
 
@@ -58,6 +60,14 @@ public class AbstractBaseMemberIntegrationTest extends AbstractBaseIntegrationTe
     memberRequest.setInstagramUrl(instagramUrl);
     memberRequest.setLinkedinUrl(linkedinUrl);
     return memberRequest;
+  }
+
+  protected String getFirstMessageError(ResponseEntity<ErrorResponse> response) {
+    return response.getBody().getMessages().get(0);
+  }
+
+  protected int getStatusValue(ResponseEntity<ErrorResponse> response) {
+    return response.getBody().getStatus();
   }
 
 }

--- a/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
@@ -117,6 +117,7 @@ public class CreateMemberIntegrationTest extends AbstractBaseMemberIntegrationTe
 
   private ResponseEntity<ErrorResponse> getErrorResponseEntity(
       CreateMemberRequest createRequest) {
+
     HttpEntity<CreateMemberRequest> request =
         new HttpEntity<>(createRequest, headers);
 

--- a/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
@@ -102,19 +102,6 @@ public class CreateMemberIntegrationTest extends AbstractBaseMemberIntegrationTe
     assertEquals("Image cannot be null or empty.",getFirstMessageError(response));
   }
 
-
-  private Member memberStub() {
-    Member member = new Member();
-    member.setName(NAME);
-    member.setImage(IMAGE);
-    member.setDescription(DESCRIPTION);
-    member.setFacebookUrl(FACEBOOK_URL);
-    member.setInstagramUrl(INSTAGRAM_URL);
-    member.setLinkedinUrl(LINKEDIN_URL);
-    member.setSoftDelete(SOFT_DELETE);
-    return member;
-  }
-
   private ResponseEntity<ErrorResponse> getErrorResponseEntity(
       CreateMemberRequest createRequest) {
 

--- a/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
@@ -1,5 +1,66 @@
 package com.alkemy.ong.integration.member;
 
-public class CreateMemberIntegrationTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import com.alkemy.ong.config.segurity.RoleType;
+import com.alkemy.ong.model.entity.Member;
+import com.alkemy.ong.model.request.CreateMemberRequest;
+import com.alkemy.ong.model.response.MemberResponse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class CreateMemberIntegrationTest extends AbstractBaseMemberIntegrationTest {
+
+  @Test
+  public void shouldReturnOkWhenAccessWithRoleUser() {
+    setAuthorizationHeaderBasedOn(RoleType.USER);
+    when(memberRepository.save(any(Member.class))).thenReturn(memberStub());
+
+    CreateMemberRequest createRequest = buildRequestPayload();
+
+    HttpEntity<CreateMemberRequest> request =
+        new HttpEntity<>(createRequest, headers);
+
+    ResponseEntity<MemberResponse> response = restTemplate
+        .exchange(createURLWithPort(PATH),
+            HttpMethod.POST,
+            request,
+            MemberResponse.class);
+
+    assertEquals(HttpStatus.CREATED,response.getStatusCode());
+
+    MemberResponse createResponse = response.getBody();
+    assertNotNull(createResponse);
+
+    assertEquals(createRequest.getName(),createResponse.getName());
+    assertEquals(createRequest.getImage(),createResponse.getImage());
+    assertEquals(createRequest.getDescription(),createResponse.getDescription());
+    assertEquals(createRequest.getFacebookUrl(),createResponse.getFacebookUrl());
+    assertEquals(createRequest.getInstagramUrl(),createResponse.getInstagramUrl());
+    assertEquals(createRequest.getLinkedinUrl(),createResponse.getLinkedinUrl());
+  }
+
+  private Member memberStub(){
+    Member member = new Member();
+    member.setName(NAME);
+    member.setImage(IMAGE);
+    member.setDescription(DESCRIPTION);
+    member.setFacebookUrl(FACEBOOK_URL);
+    member.setInstagramUrl(INSTAGRAM_URL);
+    member.setLinkedinUrl(LINKEDIN_URL);
+    member.setSoftDelete(SOFT_DELETE);
+    return member;
+  }
 }

--- a/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/CreateMemberIntegrationTest.java
@@ -1,0 +1,5 @@
+package com.alkemy.ong.integration.member;
+
+public class CreateMemberIntegrationTest {
+
+}

--- a/src/test/java/com/alkemy/ong/integration/member/GetMemberDetailsIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/GetMemberDetailsIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.alkemy.ong.integration.member;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.alkemy.ong.config.segurity.RoleType;
+import com.alkemy.ong.exception.ErrorResponse;
+import com.alkemy.ong.model.response.ListMembersResponse;
+import com.alkemy.ong.model.response.MemberResponse;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class GetMemberDetailsIntegrationTest extends AbstractBaseMemberIntegrationTest {
+
+  private final static int PAGE= 0;
+  private final static int SIZE = 10;
+
+  @Test
+  public void shouldReturnOkWhenAccessedWithAdminRole(){
+    setAuthorizationHeaderBasedOn(RoleType.ADMIN);
+
+    String url = PATH+"?page="+PAGE+"&size="+SIZE;
+
+    ResponseEntity<ListMembersResponse> response = restTemplate
+        .exchange(createURLWithPort(url),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ListMembersResponse.class);
+
+    assertEquals(HttpStatus.OK,response.getStatusCode());
+    List<MemberResponse> membersResponse = response.getBody().getMemberResponses();
+    assertNotNull(membersResponse);
+    assertEquals(1,membersResponse.size());
+    assertEquals(PAGE,response.getBody().getPage());
+    assertEquals(1,response.getBody().getTotalPages());
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenAccessedWithUserRole(){
+    setAuthorizationHeaderBasedOn(RoleType.USER);
+
+    String url = PATH+"?page="+PAGE+"&size="+SIZE;
+
+    ResponseEntity<ErrorResponse> response = restTemplate
+        .exchange(createURLWithPort(url),
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ErrorResponse.class);
+
+    assertEquals(HttpStatus.FORBIDDEN,response.getStatusCode());
+  }
+}

--- a/src/test/java/com/alkemy/ong/integration/member/ListMembersIntegrationTest.java
+++ b/src/test/java/com/alkemy/ong/integration/member/ListMembersIntegrationTest.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.integration.member;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.alkemy.ong.config.segurity.RoleType;
 import com.alkemy.ong.exception.ErrorResponse;
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,19 +22,18 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class GetMemberDetailsIntegrationTest extends AbstractBaseMemberIntegrationTest {
+public class ListMembersIntegrationTest extends AbstractBaseMemberIntegrationTest {
 
   private final static int PAGE= 0;
   private final static int SIZE = 10;
+  private final static String PAGINATION_PATH = PATH+"?page="+PAGE+"&size="+SIZE;
 
   @Test
   public void shouldReturnOkWhenAccessedWithAdminRole(){
     setAuthorizationHeaderBasedOn(RoleType.ADMIN);
 
-    String url = PATH+"?page="+PAGE+"&size="+SIZE;
-
     ResponseEntity<ListMembersResponse> response = restTemplate
-        .exchange(createURLWithPort(url),
+        .exchange(createURLWithPort(PAGINATION_PATH),
             HttpMethod.GET,
             new HttpEntity<>(headers),
             ListMembersResponse.class);
@@ -43,16 +44,15 @@ public class GetMemberDetailsIntegrationTest extends AbstractBaseMemberIntegrati
     assertEquals(1,membersResponse.size());
     assertEquals(PAGE,response.getBody().getPage());
     assertEquals(1,response.getBody().getTotalPages());
+    assertTrue(response.getHeaders().getFirst(HttpHeaders.LINK).isEmpty());
   }
 
   @Test
   public void shouldReturnForbiddenWhenAccessedWithUserRole(){
     setAuthorizationHeaderBasedOn(RoleType.USER);
 
-    String url = PATH+"?page="+PAGE+"&size="+SIZE;
-
     ResponseEntity<ErrorResponse> response = restTemplate
-        .exchange(createURLWithPort(url),
+        .exchange(createURLWithPort(PAGINATION_PATH),
             HttpMethod.GET,
             new HttpEntity<>(headers),
             ErrorResponse.class);


### PR DESCRIPTION
These are the get and create test of member controller. When the other two endpoints were merge to the project, i push this PR with the other two tests.
Proove of the get test:
![image](https://user-images.githubusercontent.com/81248632/154320026-2abef246-d6a0-40b6-ba74-1620f69013f2.png)
Proove of the create test:
![image](https://user-images.githubusercontent.com/81248632/154320593-d8f30763-df69-4376-bb5e-83c35d2dc28a.png)
I think i could refactor the code to add more commons method to the base, because i will need it in the other tests. With the other push i will refactor it.